### PR TITLE
Update SimulatePlanes.cs

### DIFF
--- a/Assets/Plugins/Unity.XR.Mock/Editor/SimulatePlanes.cs
+++ b/Assets/Plugins/Unity.XR.Mock/Editor/SimulatePlanes.cs
@@ -45,6 +45,8 @@ namespace UnityEngine.XR.Mock.Example
             }
         }
 
-        Pose pose { get { return new Pose(transform.localPosition, transform.localRotation); } }
+        //Pose pose { get { return new Pose(transform.localPosition, transform.localRotation); } }
+         Pose pose { get { return new Pose(transform.position, transform.rotation); } }
+
     }
 }


### PR DESCRIPTION
Fix for the issue where instantiated simulated planes always apearing at the position of "AR Camera" irespective of their actual positioning  in the scene. (I used AR Foundation 2.1.x and Unity 2019.3)